### PR TITLE
Add github repository URL to typst.toml

### DIFF
--- a/typst.toml
+++ b/typst.toml
@@ -6,3 +6,4 @@ exclude = ["sandbox.typ", "*.pdf", "assets/*"]
 authors = ["Daniel Csillag"]
 license = "MIT"
 description = "Theorem environments with minimal fuss"
+repository = "https://github.com/dccsillag/minienvs.typ"


### PR DESCRIPTION
Hi dccsillag,

Thanks for open sourcing your Typst theorem environment package 😄 

Noticed that the `typst.toml` file could be slightly improved by adding your minienvs.typ github repository url `https://github.com/dccsillag/minienvs.typ` to it – which is what this PR concerns. This change should eventually result in this repository url appearing on https://typst.app/universe/package/minienvs as:

Author: Daniel Csillag
License: MIT
Current version: 0.1.0
Last updated: December 14, 2023
First released: December 14, 2023
Archive size: 3.13 kB
Repository: [Github](https://github.com/dccsillag/minienvs.typ)  &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; (**Added in this PR**)

Hopefully this will help channel people browsing theorem packages on Typst's Universe page to your github repo. 
