### PR TITLE
Update to Typst v0.11.0

### DIFF
--- a/minienvs.typ
+++ b/minienvs.typ
@@ -58,14 +58,14 @@
 
   let c = counter(_counter_prefix + kind)
   c.step()
-  locate(loc => _current.update((head: head, count: c.at(loc))))
+  context _current.update((head: head, count: c.get()))
 
   let head-format = config.head-style.at(kind, default: it => [*#{it}*])
 
   block({
     head-format[#head]
     if not config.no-numbering.at(kind, default: false) {
-      head-format[ #{c.display()}]
+      head-format[ #{context c.display()}]
     }
     if tail != none {
       head-format[#tail]
@@ -83,18 +83,21 @@
   }
 
   show figure.where(kind: "minienv"): _ => []
-  show terms: (ts => _config.display(c => ts.children.map(t => _minienv(t, c)).join([])))
+  show terms: (ts => ts.children.map(t => context _minienv(t, _config.get())).join([]))
   doc
 }
 
-#let envlabel(label) = locate(loc => _current.display(current => [
-  #if current == none {
+#let envlabel(label) = context {
+  let current = _current.get()
+  if current == none {
     panic("`envlabel` used out-of-place. Must be used within the head of a minienv")
   }
-  #let relevant_counter = counter(figure.where(kind: "minienv"))
-  #let saved_count = relevant_counter.at(loc)
-  #relevant_counter.update((current.count.at(0) - 1, ..current.count.slice(1, none)))
-  #figure([], gap: 0pt, placement: none, kind: "minienv", supplement: current.head)
-  #label
-  #relevant_counter.update(saved_count)
-]))
+  let relevant_counter = counter(figure.where(kind: "minienv"))
+  let saved_count = relevant_counter.get()
+  relevant_counter.update((current.count.first() - 1, ..current.count.slice(1, none)))
+  context [
+    #figure([], gap: 0pt, placement: none, kind: "minienv", supplement: current.head)
+    #label
+  ]
+  relevant_counter.update(saved_count)
+}

--- a/minienvs.typ
+++ b/minienvs.typ
@@ -35,11 +35,7 @@
     return none
   }
 
-  if tail == none {
-    return (head.text, none)
-  } else {
-    (head.text, tail)
-  }
+  return (head.text, tail)
 }
 
 // TODO hanging indent?
@@ -95,7 +91,7 @@
   let relevant_counter = counter(figure.where(kind: "minienv"))
   let saved_count = relevant_counter.get()
   relevant_counter.update((current.count.first() - 1, ..current.count.slice(1, none)))
-  context [
+  box[
     #figure([], gap: 0pt, placement: none, kind: "minienv", supplement: current.head)
     #label
   ]

--- a/sandbox.typ
+++ b/sandbox.typ
@@ -35,7 +35,7 @@ Let us now prove it:
 
 #v(5em)
 
-/ Lemma (Donsker and Varadhan's variational formula) #envlabel(<change-of-measure>):
+/ Lemma (Donsker and Varadhan's variational formula)#envlabel(<change-of-measure>):
   For any measureable, bounded function $h : Theta -> RR$ we have:
 
   $ log EE_(theta ~ pi)[exp h(theta)] = sup_(rho in cal(P)(Theta)) [ EE_(theta~rho)[h(theta)] - KL(rho || pi) ]. $
@@ -68,7 +68,7 @@ Hello World!
 
   bar
 
-/ Theorem #envlabel(<theorem-a>):
+/ Theorem#envlabel(<theorem-a>):
   foo
 
 / Proof:

--- a/typst.toml
+++ b/typst.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minienvs"
-version = "0.1.0"
+version = "0.1.2"
 entrypoint = "minienvs.typ"
 exclude = ["sandbox.typ", "*.pdf", "assets/*"]
 authors = ["Daniel Csillag"]


### PR DESCRIPTION
Numbering seems to be broken with Typst v0.11.0 because of the changes to locate and counter (https://typst.app/docs/changelog/#v0.11.0). So I replaced these with the new context expressions and contextual functions (https://typst.app/docs/reference/context/), which seems to fix the numbering in my project at least.

Thank you for this cool package, it has been very useful!